### PR TITLE
Add filter requests by type

### DIFF
--- a/backend/services/request_service.py
+++ b/backend/services/request_service.py
@@ -15,6 +15,9 @@ def requests_by_filters(filters, page=1, per_page=10):
     if filters.get("status"):
         records = records.filter(status=filters.get("status"))
 
+    if filters.get("type"):
+        records = records.filter(type=filters.get("type"))
+
     if filters.get("id"):
         records = records.filter(id=filters.get("id"))
 


### PR DESCRIPTION
### What does it fix?

Closes #117 

1. Have added request filter by "type"
Example: http://localhost:5000/api/requests/filters/1/50?type=medicine

### How has it been tested?

1. http://localhost:5000/api/requests/filters/1/50?type=medicine - returns all requests with type medicine

2. http://localhost:5000/api/requests/filters/1/50?type=medicine&status=archived - returns all requests with type medicine in status archived

3. http://localhost:5000/api/requests/filters/1/50?type= - returns all requests because type value is empty