### PR TITLE
Add /api/clusters endpoint

### DIFF
--- a/backend/app.py
+++ b/backend/app.py
@@ -26,6 +26,7 @@ from endpoints import (
     getTags,
     register_notification,
     get_notifications_by_filters,
+    register_cluster,
 )
 from endpoints.requests import get_requests_by_id
 from endpoints.volunteer import volunteer_build_csv
@@ -196,6 +197,13 @@ def new_notification():
 @auth.login_required
 def get_notification_by_filters(pages=1, per_page=10):
     return get_notifications_by_filters(request.args, pages, per_page)
+
+
+# clusters
+@app.route("/api/clusters", methods=["POST"])
+@auth.login_required
+def new_cluster():
+    return register_cluster(request.json)
 
 
 # debug part

--- a/backend/endpoints/__init__.py
+++ b/backend/endpoints/__init__.py
@@ -14,3 +14,4 @@ from .tags import getTags, registerTag, updateTag
 from .volunteer import get_volunteers_by_filters, getVolunteers, register_volunteer, sort_closest, updateVolunteer
 from .user_request import create_request
 from .notification import register_notification, get_notifications_by_filters
+from .cluster import register_cluster

--- a/backend/endpoints/cluster.py
+++ b/backend/endpoints/cluster.py
@@ -1,0 +1,45 @@
+from models import Request, Volunteer, Cluster
+from flask import jsonify
+
+
+def register_cluster(request_json):
+    """Creates and persists a new cluster into database.
+
+    Parameters
+    ----------
+    request_json : dict
+        A dictionary representing the cluster details.
+        example {
+                  "volunteer": "volunteer_id",
+                  "request_list": ['request_id_1', 'request_id_2', ....],
+                  "created_at":  "2020-09-10T21:31:16.741Z"
+                }
+
+    Returns
+    -------
+    201:
+        If the cluster was successful created and saved.
+    400:
+        If the cluster wasn't created or saved, and there was raised some exception.
+    """
+
+    try:
+        volunteer = Volunteer.objects.get(id=request_json["volunteer"])
+        if volunteer is None:
+            return jsonify({"error": "Volunteer is not found"}), 400
+
+        request_list = request_json["request_list"]
+        if len(request_list) == 0:
+            return jsonify({"error": "request_list is empty"}), 400
+
+        new_cluster = Cluster(volunteer=volunteer)
+        new_cluster.save()
+
+        for request_id in request_list:
+            request = Request.objects.get(id=request_id)
+            request.cluster = new_cluster
+            request.save()
+
+        return jsonify({"response": "success", "cluster": new_cluster.clean_data()}), 201
+    except Exception as error:
+        return jsonify({"error": str(error)}), 400

--- a/backend/models/cluster_model.py
+++ b/backend/models/cluster_model.py
@@ -10,3 +10,9 @@ class Cluster(Document):
 
     volunteer = ReferenceField(Volunteer, required=True)
     created_at = DateTimeField(default=datetime.now())
+
+    def clean_data(self) -> dict:
+        data = self.to_mongo()
+        data["_id"] = str(data["_id"])
+        data["volunteer"] = str(data["volunteer"])
+        return data


### PR DESCRIPTION
### What does it fix?

Closes #107 

1. Add register_cluster function
It checks first if provided volunteer can be found in database, next check that "request_list" is not empty.
After it creates Cluster object and assign it's id for each Request from "request_list"
2. Add clean_data method for Cluster model

### How has it been tested?

http://localhost:5000/api/clusters
1. POST parameters
```
{
  "volunteer": "5f8e08276ceb11d64fcd9581",
  "request_list": ["5f8e08276ceb11d64fcd958b", "5f8e08276ceb11d64fcd9596", "5f8e08276ceb11d64fcd9593"]
}
```

Response
```
{
    "cluster": {
        "_id": "5f8e209fa1623d42ef04d6a0",
        "created_at": "Mon, 19 Oct 2020 23:15:28 GMT",
        "volunteer": "5f8e08276ceb11d64fcd9581"
    },
    "response": "success"
}
```

2. POST parameters
```
{
  "volunteer": "5f8e08276ceb11d64fcd9581",
  "request_list": []
}
```

Response
```
{
    "error": "request_list is empty"
}
```
