### PR TITLE
Vb20 filter the beneficiary using phone and landline

### DIFF
--- a/backend/endpoints/beneficiary.py
+++ b/backend/endpoints/beneficiary.py
@@ -115,9 +115,7 @@ def get_beneficiaries_by_filters(filters, pages=0, per_page=10000):
 
             if len(search_query):
                 query_search_fields = ["first_name", "last_name", "phone"]
-                obj = search.model_keywords_search(Beneficiary, query_search_fields, search_query.split()).filter(
-                    **flt
-                )
+                obj = search.model_keywords_search(Beneficiary, query_search_fields, search_query.split()).filter(**flt)
             else:
                 obj = Beneficiary.objects().filter(**flt)
 

--- a/backend/endpoints/beneficiary.py
+++ b/backend/endpoints/beneficiary.py
@@ -96,23 +96,26 @@ def get_beneficiaries_by_filters(filters, pages=0, per_page=10000):
         offset = (int(pages) - 1) * item_per_age
         if len(filters) > 0:
             flt = {}
+            search_query = {}
             to_bool = {"true": True, "false": False}
-            case = ["zone", "is_active", "black_list", "status"]
+            case = ["query", "zone", "is_active", "black_list", "status", "phone", "landline"]
 
             for key, value in filters.items():
-                if key not in case and key != "query":
+                if key not in case:
                     return jsonify({"error": key + " key can't be found"}), 400
+                elif key == "query" and value:
+                    search_query = value
                 elif key in ["is_active", "black_list"]:
                     if value.lower() not in to_bool:
                         return jsonify({"error": "boolean " + key + " accept only true/false values"}), 400
                     else:
                         flt[key] = to_bool[value.lower()]
-                elif key == "zone" and value:
+                elif value:
                     flt[key] = value
 
-            if "query" in filters.keys() and len(filters["query"]) > 0:
+            if len(search_query):
                 query_search_fields = ["first_name", "last_name", "phone"]
-                obj = search.model_keywords_search(Beneficiary, query_search_fields, filters["query"].split()).filter(
+                obj = search.model_keywords_search(Beneficiary, query_search_fields, search_query.split()).filter(
                     **flt
                 )
             else:

--- a/backend/seeds.py
+++ b/backend/seeds.py
@@ -98,7 +98,7 @@ def seed_db_command():
             zone="ciocana",
             address="str. Stefan cel Mare 55",
             is_active=True,
-            landline="22022022"
+            landline="22022022",
         ),
         SeedBeneficiary(
             first_name="Ghenadii",
@@ -107,7 +107,7 @@ def seed_db_command():
             zone="centru",
             address="str. Stefan cel Mare 66",
             is_active=True,
-            landline="22024025"
+            landline="22024025",
         ),
         SeedBeneficiary(
             first_name="Pavel", last_name="Velikov", phone="79000006", zone="riscani", address="str. Stefan cel Mare 43"

--- a/backend/seeds.py
+++ b/backend/seeds.py
@@ -32,6 +32,7 @@ class SeedBeneficiary(NamedTuple):
     zone: Zone
     address: str
     phone: str = None
+    landline: str = None
     is_active: bool = False
 
 
@@ -97,6 +98,7 @@ def seed_db_command():
             zone="ciocana",
             address="str. Stefan cel Mare 55",
             is_active=True,
+            landline="22022022"
         ),
         SeedBeneficiary(
             first_name="Ghenadii",
@@ -105,6 +107,7 @@ def seed_db_command():
             zone="centru",
             address="str. Stefan cel Mare 66",
             is_active=True,
+            landline="22024025"
         ),
         SeedBeneficiary(
             first_name="Pavel", last_name="Velikov", phone="79000006", zone="riscani", address="str. Stefan cel Mare 43"
@@ -149,6 +152,7 @@ def seed_db_command():
                 "first_name": beneficiary.first_name,
                 "last_name": beneficiary.last_name,
                 "phone": beneficiary.phone,
+                "landline": beneficiary.landline,
                 "zone": beneficiary.zone,
                 "address": beneficiary.address,
                 "is_active": beneficiary.is_active,

--- a/backend/static/swagger.yaml
+++ b/backend/static/swagger.yaml
@@ -426,20 +426,20 @@ paths:
             type: boolean
           description: Search for active/inactive beneficiaries
         - in: query
-            name: black_list
-            schema:
-              type: boolean
-            description: Search for black_list beneficiaries
+          name: black_list
+          schema:
+            type: boolean
+          description: Search for black_list beneficiaries
         - in: query
-            name: phone
-            schema:
-              type: integer
-            description: Search filter by phone
+          name: phone
+          schema:
+            type: integer
+          description: Search filter by phone
         - in: query
-            name: landline
-            schema:
-              type: integer
-            description: Search filter by landline
+          name: landline
+          schema:
+            type: integer
+          description: Search filter by landline
       responses:
         '200':
           description: Beneficiaries founded

--- a/backend/static/swagger.yaml
+++ b/backend/static/swagger.yaml
@@ -425,6 +425,21 @@ paths:
           schema:
             type: boolean
           description: Search for active/inactive beneficiaries
+        - in: query
+            name: black_list
+            schema:
+              type: boolean
+            description: Search for black_list beneficiaries
+        - in: query
+            name: phone
+            schema:
+              type: integer
+            description: Search filter by phone
+        - in: query
+            name: landline
+            schema:
+              type: integer
+            description: Search filter by landline
       responses:
         '200':
           description: Beneficiaries founded


### PR DESCRIPTION
What does it fix?

Reopen Pull Request

Closes #116

    Have added "phone" and "landline" parameters to search for beneficiary by exact value
    To search by "phone" and "landline" we have to add "phone" and "landline" parameters in GET HTTP parameters
    Example: http://localhost:5000/api/beneficiary/filters/1/5?landline=22835600&phone=68078000
    It will returns result only on exact match.

    Have added "landline" value for test beneficiaries in seeds.py

    Have optimized logic of get_beneficiaries_by_filters to be more readable and to more easy add new parameters to exact search.

How has it been tested?

    http://localhost:5000/api/beneficiary/filters/1/5?landline=22835600&phone=68078000 - returns one beneficiary with exact phone and landline

{
  "count": 1, 
  "list": [
    {
      "_id": "5f8d4ee2ba0f4caff7c5ea25", 
      "landline": "22835600", 
      "last_name": "Troscot", 
      "offer": "1", 
      "phone": "68078000", 
       .......
    }
  ]
}

    http://localhost:5000/api/beneficiary/filters/1/5?landline=22022022

{
  "count": 1, 
  "list": [
    {
      "_id": "5f8d4ee2ba0f4caff7c5ea13", 
      "first_name": "Valerii", 
      "landline": "22022022", 
        .....
    }
  ]
}

    http://localhost:5000/api/beneficiary/filters/1/5?phone=79000003

{
  "count": 1, 
  "list": [
    {
      "_id": "5f8d4ee2ba0f4caff7c5ea13", 
      "first_name": "Valerii", 
      "last_name": "Krisp", 
      "phone": "79000003", 
      .....
    }
  ]
}

    http://localhost:5000/api/beneficiary/filters/1/5?query=Ghenadii%20Sidorov

[{
  "count": 1, 
  "list": [
    {
      "_id": "5f8d4ee2ba0f4caff7c5ea14", 
      "first_name": "Ghenadii", 
      "last_name": "Sidorov", 
       ......
    }
  ]
}]
